### PR TITLE
Fix duplicate login bugzilla subcommand.

### DIFF
--- a/cmd/login/bugzilla.go
+++ b/cmd/login/bugzilla.go
@@ -2,15 +2,15 @@ package login
 
 import (
 	"fmt"
-	"github.com/zalando/go-keyring"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+	"github.com/zalando/go-keyring"
 )
 
 const (
 	service = "bugzilla"
-	user = "io.olm.cop"
+	user    = "io.olm.cop"
 )
 
 var BugzillaLoginCmd = &cobra.Command{
@@ -20,7 +20,7 @@ var BugzillaLoginCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		prompt := promptui.Prompt{
 			Label: "API key: ",
-			Mask: '*',
+			Mask:  '*',
 		}
 
 		key, err := prompt.Run()

--- a/cmd/login/jira.go
+++ b/cmd/login/jira.go
@@ -2,10 +2,10 @@ package login
 
 import (
 	"fmt"
-	"github.com/zalando/go-keyring"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+	"github.com/zalando/go-keyring"
 )
 
 const (
@@ -32,7 +32,7 @@ var JiraLoginCmd = &cobra.Command{
 
 		prompt = promptui.Prompt{
 			Label: "Password: ",
-			Mask: '*',
+			Mask:  '*',
 		}
 
 		pass, err := prompt.Run()
@@ -48,5 +48,5 @@ var JiraLoginCmd = &cobra.Command{
 }
 
 func init() {
-	LoginCmd.AddCommand(BugzillaLoginCmd)
+	LoginCmd.AddCommand(JiraLoginCmd)
 }

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -24,6 +24,5 @@ var LoginCmd = &cobra.Command{
 }
 
 func init() {
-	LoginCmd.AddCommand(BugzillaLoginCmd)
 	LoginCmd.PersistentFlags().BoolVarP(&loginOpts.debug, "debug", "d", false, "enable debug logging")
 }


### PR DESCRIPTION
```
$ cop help login
manage credentials for required services.

Usage:
  cop login [flags]
  cop login [command]

Available Commands:
  bugzilla    bugzilla login
  bugzilla    bugzilla login
  bugzilla    bugzilla login
```